### PR TITLE
create signup logic

### DIFF
--- a/prisma/migrations/20221011135517_update_models/migration.sql
+++ b/prisma/migrations/20221011135517_update_models/migration.sql
@@ -1,0 +1,44 @@
+/*
+  Warnings:
+
+  - You are about to drop the `Bookmark` table. If the table is not empty, all the data it contains will be lost.
+  - You are about to drop the `User` table. If the table is not empty, all the data it contains will be lost.
+
+*/
+-- DropTable
+DROP TABLE "Bookmark";
+
+-- DropTable
+DROP TABLE "User";
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "email" TEXT NOT NULL,
+    "hash" TEXT NOT NULL,
+    "firstName" TEXT,
+    "lastName" TEXT,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "bookmarks" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "title" TEXT NOT NULL,
+    "description" TEXT,
+    "link" TEXT NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "bookmarks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_email_key" ON "users"("email");
+
+-- AddForeignKey
+ALTER TABLE "bookmarks" ADD CONSTRAINT "bookmarks_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,11 +15,15 @@ model User {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  email String
+  email String @unique
   hash  String
 
   firstName String?
   lastName  String?
+
+  bookmarks Bookmark[]
+
+  @@map("users")
 }
 
 model Bookmark {
@@ -30,4 +34,9 @@ model Bookmark {
   title       String 
   description String?
   link        String
+
+  userId Int
+  user User @relation(fields: [userId], references: [id])
+
+  @@map("bookmarks")
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,7 +1,8 @@
-import { Injectable } from "@nestjs/common";
+import { ForbiddenException, Injectable } from "@nestjs/common";
 import { PrismaService } from "src/prisma/prisma.service";
 import { AuthDto } from "./dto";
 import * as argon from "argon2";
+import { PrismaClientKnownRequestError } from "@prisma/client/runtime";
 
 @Injectable()
 export class AuthService {
@@ -11,15 +12,39 @@ export class AuthService {
         // generate the password hash
         const hash = await argon.hash(dto.password)
         // save the new user in the db
-        const user = await this.prisma.user.create({
-            data: {
-                email: dto.email,
-                hash,
+        try {
+            const user = await this.prisma.user.create({
+                data: {
+                    email: dto.email,
+                    hash,
+                },
+                // con il selettore andiamo a selezionare solo i campi desiderati
+                // ma non è molto comodo 
+                // select: {
+                //     id: true,
+                //     email: true,
+                //     createdAt: true
+                // }
+            });
+            // per ora eliminiamo solo l'hash dall'oggetto di ritorno
+            delete user.hash;
+            // return the saved user
+            return user;
+        } catch (error) {
+            //se è un errore di prisma e non di qualcos'altro
+            // prisma ha codici di errore definiti e questo signidica che provi a crearne uno nuovo
+            // record con i campi univoci che sono stati violari
+            // 'P2002' = duplicated field
+            if (error instanceof PrismaClientKnownRequestError) {
+                if (error.code === 'P2002') {
+                    throw new ForbiddenException(
+                        'Credentials taken'
+                    )
+                }
             }
-        });
-        // return the saved user
-        return user
+        }
     }
+
 
     signin() { return { msg: 'I have signed in' } }
 }


### PR DESCRIPTION
Mappiamo i nomi sullo schema.prisma su un altro nome ("users") ed ("bookmarks")
Creiamo un collegamento relazione 
MANY TO ONE CONNECTION tra utenti e bookmarks 
Così i preferiti(bookmarks) apparterranno all'utente 
Molti preferiti possono appartenere ad uno stesso utente, 
ma ogni dato segnalibro in un dato momento appartiene solo ad un utente.
Facciamo la migrazione del nuovo schema (sostituendolo al vecchio) 
npx prisma migrate dev 
nome: update models

Error handling:
per evitare che ci ritorni uno status 500 che non dice nulla ed è troppo generico
in auth.service.ts
creiamo l'errore "credenziali già prese" 