### PR TITLE
added scripts to automate postgres & prisma

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
+    "prisma:dev:deploy":"prisma migrate deploy",
+    "db:dev:rm":"docker compose rm dev-db -s -f -v",
+    "db:dev:up":"docker compose up dev-db -d",
+    "db:dev:restart":"npm run db:dev:rm && npm run db:dev:up && sleep 1 && npm run prisma:dev:deploy",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",


### PR DESCRIPTION
Added scripts to automate postgres restart and prisma migrations: 
"prisma:dev:deploy":"prisma migrate deploy",    
"db:dev:rm":"docker compose rm dev-db -s -f -v",
"db:dev:up":"docker compose up dev-db -d",

and one for all 
"db:dev:restart":"npm run db:dev:rm && npm run db:dev:up && sleep 1 && npm run prisma:dev:deploy",